### PR TITLE
fix(Downloader): Don't use ARRAY_FILTER_USE_KEY option

### DIFF
--- a/src/Service/DownloaderService.php
+++ b/src/Service/DownloaderService.php
@@ -65,8 +65,7 @@ class DownloaderService
             $courses,
             function ($title) use ($coursesWanted) {
                 return in_array($title, $coursesWanted);
-            },
-            ARRAY_FILTER_USE_KEY
+            }
         );
 
         $this->io->section('Wanted courses');


### PR DESCRIPTION
Hey,

I've reached you by mail and found the issue. If you use the `ARRAY_FILTER_USE_KEY` option in array_filter, you won't match it in the in_array check.
> ARRAY_FILTER_USE_KEY - pass key as the only argument to callback instead of the value

This fix rthe issue ;)